### PR TITLE
Add option to have relative include paths

### DIFF
--- a/swift-generator-cli/src/main/java/com/facebook/swift/generator/Main.java
+++ b/swift-generator-cli/src/main/java/com/facebook/swift/generator/Main.java
@@ -62,7 +62,8 @@ public class Main
                 .overridePackage(cliConfig.overridePackage)
                 .defaultPackage(cliConfig.defaultPackage)
                 .generateIncludedCode(cliConfig.generateIncludedCode)
-                .codeFlavor(cliConfig.generateBeans ? "java-regular" : "java-immutable");
+                .codeFlavor(cliConfig.generateBeans ? "java-regular" : "java-immutable")
+                .includePathsRelativeToFile(cliConfig.includePathsRelativeToFile);
 
         for (SwiftGeneratorTweak tweak : cliConfig.tweaks) {
             configBuilder.addTweak(tweak);

--- a/swift-generator-cli/src/main/java/com/facebook/swift/generator/SwiftGeneratorCommandLineConfig.java
+++ b/swift-generator-cli/src/main/java/com/facebook/swift/generator/SwiftGeneratorCommandLineConfig.java
@@ -75,9 +75,15 @@ public class SwiftGeneratorCommandLineConfig
     )
     public boolean usePlainJavaNamespace = false;
 
-  @Parameter(
-      names = "-fallback_to_java_namespace",
-      description = "Use 'java' namespace if 'java.swift' namespace is not present"
-  )
-  public boolean fallbackToPlainJavaNamespace = false;
+    @Parameter(
+            names = "-fallback_to_java_namespace",
+            description = "Use 'java' namespace if 'java.swift' namespace is not present"
+    )
+    public boolean fallbackToPlainJavaNamespace = false;
+
+    @Parameter(
+            names = "-include_paths_relative_to_file",
+            description = "Include paths are relative to the file in which they are contained"
+    )
+    public boolean includePathsRelativeToFile = false;
 }

--- a/swift-generator/src/main/java/com/facebook/swift/generator/SwiftGenerator.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/SwiftGenerator.java
@@ -173,7 +173,9 @@ public class SwiftGenerator
                 }
 
                 if (foundIncludeUri == null) {
-                    foundIncludeUri = swiftGeneratorConfig.getInputBase().resolve(include);
+                    foundIncludeUri = swiftGeneratorConfig.isIncludePathsRelativeToFile() ?
+                        thriftUri.resolve(include) :
+                        swiftGeneratorConfig.getInputBase().resolve(include);
                 }
 
                 LOG.debug("Found %s included from %s.", foundIncludeUri, thriftUri);

--- a/swift-generator/src/main/java/com/facebook/swift/generator/SwiftGeneratorConfig.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/SwiftGeneratorConfig.java
@@ -33,6 +33,7 @@ public class SwiftGeneratorConfig
     private final Set<SwiftGeneratorTweak> generatorTweaks;
     private final boolean generateIncludedCode;
     private final String codeFlavor;
+    private final boolean includePathsRelativeToFile;
 
     private SwiftGeneratorConfig(
             final URI inputBase,
@@ -41,7 +42,8 @@ public class SwiftGeneratorConfig
             final String defaultPackage,
             final Set<SwiftGeneratorTweak> generatorTweaks,
             final boolean generateIncludedCode,
-            final String codeFlavor)
+            final String codeFlavor,
+            final boolean includePathsRelativeToFile)
     {
         this.inputBase = inputBase;
         this.includeSearchPaths = includeSearchPaths;
@@ -51,6 +53,7 @@ public class SwiftGeneratorConfig
         this.generatorTweaks = generatorTweaks;
         this.generateIncludedCode = generateIncludedCode;
         this.codeFlavor = codeFlavor;
+        this.includePathsRelativeToFile = includePathsRelativeToFile;
     }
 
     public static Builder builder()
@@ -123,6 +126,14 @@ public class SwiftGeneratorConfig
         return codeFlavor;
     }
 
+    /**
+     * The template to use for generating source code.
+     */
+    public boolean isIncludePathsRelativeToFile()
+    {
+        return includePathsRelativeToFile;
+    }
+
     public static class Builder
     {
         private URI inputBase = null;
@@ -133,6 +144,7 @@ public class SwiftGeneratorConfig
         private Set<SwiftGeneratorTweak> generatorTweaks = EnumSet.noneOf(SwiftGeneratorTweak.class);
         private boolean generateIncludedCode = false;
         private String codeFlavor = null;
+        private boolean includePathsRelativeToFile = false;
 
         private Builder()
         {
@@ -157,7 +169,8 @@ public class SwiftGeneratorConfig
                     defaultPackage,
                     generatorTweaks,
                     generateIncludedCode,
-                    codeFlavor);
+                    codeFlavor,
+                    includePathsRelativeToFile);
         }
 
         public Builder inputBase(final URI inputBase)
@@ -205,6 +218,12 @@ public class SwiftGeneratorConfig
         public Builder codeFlavor(final String codeFlavor)
         {
             this.codeFlavor = codeFlavor;
+            return this;
+        }
+
+        public Builder includePathsRelativeToFile(final boolean includePathsRelativeToFile)
+        {
+            this.includePathsRelativeToFile = includePathsRelativeToFile;
             return this;
         }
     }


### PR DESCRIPTION
When processing include paths, Apache thrift can understand the path as relative to the current .thrift file.
However, the swift generator currently only understand the path as relative to the current working directory, which makes it incompatible with thrift IDL repos set up using relative paths. This PR adds the option.