### PR TITLE
Add option to prefix all generated class package name

### DIFF
--- a/swift-generator-cli/src/main/java/com/facebook/swift/generator/Main.java
+++ b/swift-generator-cli/src/main/java/com/facebook/swift/generator/Main.java
@@ -63,7 +63,8 @@ public class Main
                 .defaultPackage(cliConfig.defaultPackage)
                 .generateIncludedCode(cliConfig.generateIncludedCode)
                 .codeFlavor(cliConfig.generateBeans ? "java-regular" : "java-immutable")
-                .includePathsRelativeToFile(cliConfig.includePathsRelativeToFile);
+                .includePathsRelativeToFile(cliConfig.includePathsRelativeToFile)
+                .packagePrefix(cliConfig.packagePrefix);
 
         for (SwiftGeneratorTweak tweak : cliConfig.tweaks) {
             configBuilder.addTweak(tweak);

--- a/swift-generator-cli/src/main/java/com/facebook/swift/generator/SwiftGeneratorCommandLineConfig.java
+++ b/swift-generator-cli/src/main/java/com/facebook/swift/generator/SwiftGeneratorCommandLineConfig.java
@@ -86,4 +86,10 @@ public class SwiftGeneratorCommandLineConfig
             description = "Include paths are relative to the file in which they are contained"
     )
     public boolean includePathsRelativeToFile = false;
+
+    @Parameter(
+            names = "-package_prefix",
+            description = "Adding a prefix to all the generated java package namespace"
+    )
+    public String packagePrefix = "";
 }

--- a/swift-generator/src/main/java/com/facebook/swift/generator/SwiftGenerator.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/SwiftGenerator.java
@@ -141,7 +141,7 @@ public class SwiftGenerator
         final Document document = context.getDocument();
         final Header header = document.getHeader();
 
-        String javaPackage = context.getJavaPackage();
+        String javaPackage = swiftGeneratorConfig.getPackagePrefix() + context.getJavaPackage();
 
         // Add a Constants type so that the Constants visitor can render is.
         typeRegistry.add(new SwiftJavaType(thriftNamespace, "Constants", "Constants", javaPackage));

--- a/swift-generator/src/main/java/com/facebook/swift/generator/SwiftGeneratorConfig.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/SwiftGeneratorConfig.java
@@ -34,6 +34,7 @@ public class SwiftGeneratorConfig
     private final boolean generateIncludedCode;
     private final String codeFlavor;
     private final boolean includePathsRelativeToFile;
+    private final String packagePrefix;
 
     private SwiftGeneratorConfig(
             final URI inputBase,
@@ -43,7 +44,8 @@ public class SwiftGeneratorConfig
             final Set<SwiftGeneratorTweak> generatorTweaks,
             final boolean generateIncludedCode,
             final String codeFlavor,
-            final boolean includePathsRelativeToFile)
+            final boolean includePathsRelativeToFile,
+            final String packagePrefix)
     {
         this.inputBase = inputBase;
         this.includeSearchPaths = includeSearchPaths;
@@ -54,6 +56,7 @@ public class SwiftGeneratorConfig
         this.generateIncludedCode = generateIncludedCode;
         this.codeFlavor = codeFlavor;
         this.includePathsRelativeToFile = includePathsRelativeToFile;
+        this.packagePrefix = packagePrefix;
     }
 
     public static Builder builder()
@@ -134,6 +137,14 @@ public class SwiftGeneratorConfig
         return includePathsRelativeToFile;
     }
 
+    /**
+     *
+     */
+    public String getPackagePrefix()
+    {
+        return packagePrefix;
+    }
+
     public static class Builder
     {
         private URI inputBase = null;
@@ -145,6 +156,7 @@ public class SwiftGeneratorConfig
         private boolean generateIncludedCode = false;
         private String codeFlavor = null;
         private boolean includePathsRelativeToFile = false;
+        private String packagePrefix = "";
 
         private Builder()
         {
@@ -170,7 +182,8 @@ public class SwiftGeneratorConfig
                     generatorTweaks,
                     generateIncludedCode,
                     codeFlavor,
-                    includePathsRelativeToFile);
+                    includePathsRelativeToFile,
+                    packagePrefix);
         }
 
         public Builder inputBase(final URI inputBase)
@@ -224,6 +237,12 @@ public class SwiftGeneratorConfig
         public Builder includePathsRelativeToFile(final boolean includePathsRelativeToFile)
         {
             this.includePathsRelativeToFile = includePathsRelativeToFile;
+            return this;
+        }
+
+        public Builder packagePrefix(final String packagePrefix)
+        {
+            this.packagePrefix = packagePrefix;
             return this;
         }
     }


### PR DESCRIPTION
This allows adding a prefix to all generated class namespace (package). The motivation behind this is so both apache-swift and facebook-swift generated java class from thrift IDLs can exist in the same repo and build.